### PR TITLE
Phase 7: Azure Container Apps deployment (Consumption plan)

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -1,0 +1,151 @@
+name: Build & Deploy to Azure
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      imageTag:
+        description: 'Image tag to deploy'
+        required: false
+        default: 'latest'
+
+env:
+  REGISTRY: ghcr.io
+  OWNER: ${{ github.repository_owner }}
+  IMAGE_TAG: ${{ github.sha }}
+
+jobs:
+  # ── Build & push container images ──────────────────────────────────────────
+  build-images:
+    name: Build & push images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - service: api
+            dockerfile: src/Muxity.Api/Dockerfile
+            context: .
+          - service: streaming
+            dockerfile: src/Muxity.Streaming/Dockerfile
+            context: .
+          - service: transcoder
+            dockerfile: src/Muxity.Transcoder/Dockerfile
+            context: .
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push ${{ matrix.service }}
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/muxity-${{ matrix.service }}:${{ env.IMAGE_TAG }}
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/muxity-${{ matrix.service }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ── Deploy Bicep infrastructure ────────────────────────────────────────────
+  deploy-infra:
+    name: Deploy Azure infrastructure
+    runs-on: ubuntu-latest
+    needs: build-images
+    environment: azure-preview
+    outputs:
+      apiUrl: ${{ steps.deploy.outputs.apiUrl }}
+      streamingUrl: ${{ steps.deploy.outputs.streamingUrl }}
+      webUrl: ${{ steps.deploy.outputs.webUrl }}
+      staticWebAppToken: ${{ steps.deploy.outputs.staticWebAppDeploymentToken }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Create resource group (idempotent)
+        run: |
+          az group create \
+            --name "${{ vars.AZURE_RESOURCE_GROUP }}" \
+            --location "${{ vars.AZURE_LOCATION || 'eastus' }}"
+
+      - name: Deploy Bicep
+        id: deploy
+        uses: azure/arm-deploy@v2
+        with:
+          resourceGroupName: ${{ vars.AZURE_RESOURCE_GROUP }}
+          template: infra/azure/main.bicep
+          parameters: >
+            prefix=${{ vars.AZURE_PREFIX || 'muxity' }}
+            repositoryUrl=https://github.com/${{ github.repository }}
+            branch=main
+            repositoryToken=${{ secrets.GH_PAT_STATIC_WEB_APP }}
+            rabbitMqConnectionString=${{ secrets.RABBITMQ_CONNECTION_STRING }}
+            jwtSigningKey=${{ secrets.JWT_SIGNING_KEY }}
+            googleClientId=${{ vars.GOOGLE_CLIENT_ID }}
+            microsoftClientId=${{ vars.MICROSOFT_CLIENT_ID }}
+            imageTag=${{ env.IMAGE_TAG }}
+            ghcrOwner=${{ env.OWNER }}
+          failOnStdErr: false
+
+  # ── Deploy Blazor WASM to Static Web Apps ─────────────────────────────────
+  deploy-web:
+    name: Deploy Blazor WASM
+    runs-on: ubuntu-latest
+    needs: deploy-infra
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.x'
+
+      - name: Publish Blazor WASM
+        run: |
+          dotnet publish src/Muxity.Web/Muxity.Web.csproj \
+            -c Release \
+            -o infra/azure/web-publish \
+            /p:ApiBaseUrl=https://${{ needs.deploy-infra.outputs.apiUrl }} \
+            /p:StreamingBaseUrl=https://${{ needs.deploy-infra.outputs.streamingUrl }}
+
+      - name: Deploy to Static Web Apps
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ needs.deploy-infra.outputs.staticWebAppToken }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: upload
+          app_location: infra/azure/web-publish/wwwroot
+          skip_app_build: true
+
+  # ── Print endpoints ────────────────────────────────────────────────────────
+  summary:
+    name: Deployment summary
+    runs-on: ubuntu-latest
+    needs: [deploy-infra, deploy-web]
+    steps:
+      - name: Print URLs
+        run: |
+          echo "## Muxity deployed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Service | URL |" >> $GITHUB_STEP_SUMMARY
+          echo "|---------|-----|" >> $GITHUB_STEP_SUMMARY
+          echo "| Web | https://${{ needs.deploy-infra.outputs.webUrl }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| API | https://${{ needs.deploy-infra.outputs.apiUrl }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Streaming | https://${{ needs.deploy-infra.outputs.streamingUrl }} |" >> $GITHUB_STEP_SUMMARY

--- a/infra/azure/DEPLOY.md
+++ b/infra/azure/DEPLOY.md
@@ -1,0 +1,87 @@
+# Deploying Muxity to Azure Container Apps
+
+## Prerequisites
+
+- Azure subscription (free tier works for preview)
+- [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
+- [CloudAMQP account](https://www.cloudamqp.com) — free Little Lemur plan for RabbitMQ
+- GitHub account (images pushed to GHCR, Blazor WASM to Static Web Apps)
+
+---
+
+## One-shot deploy (first time)
+
+```bash
+az login
+bash infra/azure/deploy.sh
+```
+
+You'll be prompted for:
+- **RabbitMQ connection string** — from CloudAMQP → your instance → AMQP URL
+- **JWT signing key** — auto-generated if omitted
+- **GitHub PAT** — create at github.com/settings/tokens with `repo` scope
+
+---
+
+## GitHub Actions (CI/CD after first deploy)
+
+Add these **secrets** to your repo (`Settings → Secrets and variables → Actions`):
+
+| Secret | Value |
+|--------|-------|
+| `AZURE_CREDENTIALS` | Output of `az ad sp create-for-rbac --sdk-auth` |
+| `RABBITMQ_CONNECTION_STRING` | CloudAMQP AMQPS URL |
+| `JWT_SIGNING_KEY` | 32+ random chars |
+| `GH_PAT_STATIC_WEB_APP` | GitHub PAT (repo scope) |
+
+Add these **variables**:
+
+| Variable | Example |
+|----------|---------|
+| `AZURE_RESOURCE_GROUP` | `muxity-preview` |
+| `AZURE_LOCATION` | `eastus` |
+| `AZURE_PREFIX` | `muxity` |
+| `GOOGLE_CLIENT_ID` | *(optional)* |
+| `MICROSOFT_CLIENT_ID` | *(optional)* |
+
+Then push to `main` — the workflow builds images, deploys Bicep, and publishes the Blazor WASM automatically.
+
+---
+
+## Architecture
+
+```
+GitHub Actions
+  ├── build-images → ghcr.io/rfsprog/muxity-{api,streaming,transcoder}:sha
+  ├── deploy-infra → az deployment group create (Bicep)
+  └── deploy-web   → Azure Static Web Apps (Blazor WASM)
+
+Azure Resources (all in one resource group)
+  ├── Container Apps Environment
+  │   ├── muxity-api          (0–5 replicas, scales to zero)
+  │   ├── muxity-streaming    (0–10 replicas, scales to zero)
+  │   └── muxity-transcoder   (0–3 replicas, KEDA RabbitMQ scaler)
+  ├── Azure Static Web App    (Blazor WASM, free tier)
+  ├── Azure Cosmos DB         (MongoDB API, free tier 1000 RU/s)
+  ├── Azure Storage Account
+  │   └── Azure Files share   (mounted to all 3 container apps at /data/storage)
+  └── Log Analytics workspace
+```
+
+## Estimated cost (sandbox, light usage)
+
+| Resource | Free allowance | Overage |
+|----------|---------------|---------|
+| Container Apps | 180k vCPU-s + 360k GiB-s/month | ~$0.000024/vCPU-s |
+| Static Web App | Always free | — |
+| Cosmos DB | 1000 RU/s, 25GB (free tier) | — |
+| Azure Files | — | ~$0.06/GB/month |
+| Log Analytics | 5GB/month free | $2.30/GB |
+
+**Estimated total for a preview with light traffic: ~$0–5/month**
+
+## Tear down
+
+```bash
+az group delete --name muxity-preview --yes
+```

--- a/infra/azure/deploy.sh
+++ b/infra/azure/deploy.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# deploy.sh — One-shot provisioning of Muxity on Azure Container Apps
+# Usage: bash infra/azure/deploy.sh
+#
+# Prerequisites:
+#   az login
+#   az extension add --name containerapp
+#   docker (for local image builds, optional if using GitHub Actions)
+#
+# Required environment variables (or you'll be prompted):
+#   RABBITMQ_CONNECTION_STRING  — amqps://user:pass@host/vhost  (CloudAMQP free tier)
+#   JWT_SIGNING_KEY             — random 32+ char string
+#   GH_PAT                      — GitHub PAT with repo scope (for Static Web Apps)
+#   GOOGLE_CLIENT_ID            — (optional) Google OAuth client ID
+#   MICROSOFT_CLIENT_ID         — (optional) Microsoft OAuth client ID
+
+set -euo pipefail
+
+# ── Config (override via env vars) ───────────────────────────────────────────
+RESOURCE_GROUP="${RESOURCE_GROUP:-muxity-preview}"
+LOCATION="${LOCATION:-eastus}"
+PREFIX="${PREFIX:-muxity}"
+REPO_URL="${REPO_URL:-https://github.com/rfsprog/Muxity}"
+BRANCH="${BRANCH:-main}"
+GHCR_OWNER="${GHCR_OWNER:-rfsprog}"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+
+# ── Prompt for secrets if not set ────────────────────────────────────────────
+if [[ -z "${RABBITMQ_CONNECTION_STRING:-}" ]]; then
+  echo ""
+  echo "CloudAMQP free tier: https://www.cloudamqp.com"
+  read -rsp "RabbitMQ connection string (amqps://...): " RABBITMQ_CONNECTION_STRING
+  echo ""
+fi
+
+if [[ -z "${JWT_SIGNING_KEY:-}" ]]; then
+  JWT_SIGNING_KEY=$(openssl rand -hex 32)
+  echo "Generated JWT signing key: $JWT_SIGNING_KEY"
+  echo "(save this — you'll need it if you redeploy)"
+fi
+
+if [[ -z "${GH_PAT:-}" ]]; then
+  echo ""
+  echo "GitHub PAT needed for Static Web Apps deployment."
+  echo "Create one at: https://github.com/settings/tokens (repo scope)"
+  read -rsp "GitHub PAT: " GH_PAT
+  echo ""
+fi
+
+GOOGLE_CLIENT_ID="${GOOGLE_CLIENT_ID:-}"
+MICROSOFT_CLIENT_ID="${MICROSOFT_CLIENT_ID:-}"
+
+# ── Azure setup ───────────────────────────────────────────────────────────────
+echo ""
+echo "==> Creating resource group: $RESOURCE_GROUP ($LOCATION)"
+az group create --name "$RESOURCE_GROUP" --location "$LOCATION" --output none
+
+echo "==> Registering Container Apps extension"
+az extension add --name containerapp --upgrade --output none 2>/dev/null || true
+az provider register --namespace Microsoft.App --wait --output none 2>/dev/null || true
+az provider register --namespace Microsoft.OperationalInsights --wait --output none 2>/dev/null || true
+
+# ── Deploy Bicep ──────────────────────────────────────────────────────────────
+echo "==> Deploying Bicep template (this takes ~5 minutes)..."
+
+DEPLOY_OUTPUT=$(az deployment group create \
+  --resource-group "$RESOURCE_GROUP" \
+  --template-file "$(dirname "$0")/main.bicep" \
+  --parameters \
+    "prefix=$PREFIX" \
+    "location=$LOCATION" \
+    "repositoryUrl=$REPO_URL" \
+    "branch=$BRANCH" \
+    "repositoryToken=$GH_PAT" \
+    "rabbitMqConnectionString=$RABBITMQ_CONNECTION_STRING" \
+    "jwtSigningKey=$JWT_SIGNING_KEY" \
+    "googleClientId=$GOOGLE_CLIENT_ID" \
+    "microsoftClientId=$MICROSOFT_CLIENT_ID" \
+    "imageTag=$IMAGE_TAG" \
+    "ghcrOwner=$GHCR_OWNER" \
+  --output json)
+
+API_URL=$(echo "$DEPLOY_OUTPUT" | jq -r '.properties.outputs.apiUrl.value')
+STREAMING_URL=$(echo "$DEPLOY_OUTPUT" | jq -r '.properties.outputs.streamingUrl.value')
+WEB_URL=$(echo "$DEPLOY_OUTPUT" | jq -r '.properties.outputs.webUrl.value')
+
+# ── Print summary ─────────────────────────────────────────────────────────────
+echo ""
+echo "============================================================"
+echo "  Muxity deployed successfully!"
+echo "============================================================"
+echo ""
+echo "  Web:       https://$WEB_URL"
+echo "  API:       $API_URL"
+echo "  Streaming: $STREAMING_URL"
+echo ""
+echo "Next steps:"
+echo "  1. Push container images to ghcr.io/$GHCR_OWNER/muxity-{api,streaming,transcoder}:$IMAGE_TAG"
+echo "     (GitHub Actions does this automatically on push to main)"
+echo "  2. Configure GitHub Actions secrets — see DEPLOY.md"
+echo "  3. Set GOOGLE_CLIENT_ID / MICROSOFT_CLIENT_ID and re-run to enable OIDC login"
+echo ""
+echo "To tear down:"
+echo "  az group delete --name $RESOURCE_GROUP --yes"
+echo ""

--- a/infra/azure/main.bicep
+++ b/infra/azure/main.bicep
@@ -1,0 +1,103 @@
+@description('Azure region for all resources')
+param location string = resourceGroup().location
+
+@description('Short prefix used for all resource names (e.g. muxity-preview)')
+param prefix string = 'muxity'
+
+@description('GitHub repository URL')
+param repositoryUrl string = 'https://github.com/rfsprog/Muxity'
+
+@description('Branch to deploy Blazor WASM from')
+param branch string = 'main'
+
+@description('GitHub PAT for Static Web Apps (repo scope)')
+@secure()
+param repositoryToken string
+
+@description('RabbitMQ connection string from CloudAMQP (amqps://...)')
+@secure()
+param rabbitMqConnectionString string
+
+@description('JWT signing key — min 32 random characters')
+@secure()
+param jwtSigningKey string
+
+@description('Google OAuth client ID (leave empty to disable)')
+param googleClientId string = ''
+
+@description('Microsoft OAuth client ID (leave empty to disable)')
+param microsoftClientId string = ''
+
+@description('Container image tag to deploy')
+param imageTag string = 'latest'
+
+@description('GitHub Container Registry owner (repo owner lowercase)')
+param ghcrOwner string = 'rfsprog'
+
+// ── Storage ──────────────────────────────────────────────────────────────────
+module storage 'modules/storage.bicep' = {
+  name: 'storage'
+  params: {
+    location: location
+    prefix: prefix
+  }
+}
+
+// ── Cosmos DB (MongoDB API) ───────────────────────────────────────────────────
+module cosmos 'modules/cosmos.bicep' = {
+  name: 'cosmos'
+  params: {
+    location: location
+    prefix: prefix
+  }
+}
+
+// ── Container Apps environment ────────────────────────────────────────────────
+module env 'modules/containerAppsEnv.bicep' = {
+  name: 'containerAppsEnv'
+  params: {
+    location: location
+    prefix: prefix
+    storageAccountName: storage.outputs.storageAccountName
+    fileShareName: storage.outputs.fileShareName
+    storageAccountKey: storage.outputs.storageAccountKey
+  }
+}
+
+// ── Container Apps ────────────────────────────────────────────────────────────
+module apps 'modules/containerApps.bicep' = {
+  name: 'containerApps'
+  params: {
+    location: location
+    prefix: prefix
+    envId: env.outputs.envId
+    storageMountName: env.outputs.storageMountName
+    mongoConnectionString: cosmos.outputs.connectionString
+    mongoDatabaseName: cosmos.outputs.databaseName
+    rabbitMqConnectionString: rabbitMqConnectionString
+    jwtSigningKey: jwtSigningKey
+    jwtIssuer: 'https://${apps.outputs.apiHostname}'
+    googleClientId: googleClientId
+    microsoftClientId: microsoftClientId
+    imageTag: imageTag
+    ghcrOwner: ghcrOwner
+  }
+}
+
+// ── Static Web App (Blazor WASM) ──────────────────────────────────────────────
+module web 'modules/staticWebApp.bicep' = {
+  name: 'staticWebApp'
+  params: {
+    location: location
+    prefix: prefix
+    repositoryUrl: repositoryUrl
+    branch: branch
+    repositoryToken: repositoryToken
+  }
+}
+
+// ── Outputs ───────────────────────────────────────────────────────────────────
+output apiUrl string = 'https://${apps.outputs.apiHostname}'
+output streamingUrl string = 'https://${apps.outputs.streamingHostname}'
+output webUrl string = 'https://${web.outputs.defaultHostname}'
+output staticWebAppDeploymentToken string = web.outputs.deploymentToken

--- a/infra/azure/modules/containerApps.bicep
+++ b/infra/azure/modules/containerApps.bicep
@@ -1,0 +1,244 @@
+@description('Azure region for all resources')
+param location string
+
+@description('Name prefix for resources')
+param prefix string
+
+@description('Container Apps environment ID')
+param envId string
+
+@description('Storage mount name configured on the environment')
+param storageMountName string
+
+@description('MongoDB connection string')
+@secure()
+param mongoConnectionString string
+
+@description('MongoDB database name')
+param mongoDatabaseName string
+
+@description('RabbitMQ connection string (amqps://...)')
+@secure()
+param rabbitMqConnectionString string
+
+@description('JWT signing key (min 32 chars)')
+@secure()
+param jwtSigningKey string
+
+@description('JWT issuer')
+param jwtIssuer string = 'https://muxity.example.com'
+
+@description('Google OIDC client ID')
+param googleClientId string = ''
+
+@description('Microsoft OIDC client ID')
+param microsoftClientId string = ''
+
+@description('Container image tag')
+param imageTag string = 'latest'
+
+@description('GitHub Container Registry username (repo owner)')
+param ghcrOwner string = 'rfsprog'
+
+var storageMountPath = '/data/storage'
+var registry = 'ghcr.io'
+
+var commonEnv = [
+  { name: 'MongoDB__ConnectionString', secretRef: 'mongo-connection' }
+  { name: 'MongoDB__DatabaseName', value: mongoDatabaseName }
+  { name: 'Storage__Provider', value: 'Local' }
+  { name: 'Storage__Local__BasePath', value: storageMountPath }
+  { name: 'ASPNETCORE_ENVIRONMENT', value: 'Production' }
+]
+
+var commonSecrets = [
+  { name: 'mongo-connection', value: mongoConnectionString }
+  { name: 'jwt-key', value: jwtSigningKey }
+]
+
+var commonVolumes = [
+  {
+    name: 'storage-vol'
+    storageType: 'AzureFile'
+    storageName: storageMountName
+  }
+]
+
+var commonVolumeMounts = [
+  {
+    volumeName: 'storage-vol'
+    mountPath: storageMountPath
+  }
+]
+
+// ── API ──────────────────────────────────────────────────────────────────────
+resource apiApp 'Microsoft.App/containerApps@2024-03-01' = {
+  name: '${prefix}-api'
+  location: location
+  properties: {
+    environmentId: envId
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 8080
+        transport: 'http'
+        corsPolicy: {
+          allowedOrigins: ['*']
+          allowedHeaders: ['*']
+          allowedMethods: ['*']
+        }
+      }
+      secrets: union(commonSecrets, [
+        { name: 'rabbitmq-connection', value: rabbitMqConnectionString }
+      ])
+    }
+    template: {
+      volumes: commonVolumes
+      containers: [
+        {
+          name: 'api'
+          image: '${registry}/${ghcrOwner}/muxity-api:${imageTag}'
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+          env: union(commonEnv, [
+            { name: 'Jwt__Key', secretRef: 'jwt-key' }
+            { name: 'Jwt__Issuer', value: jwtIssuer }
+            { name: 'RabbitMq__ConnectionString', secretRef: 'rabbitmq-connection' }
+            { name: 'Oidc__Google__ClientId', value: googleClientId }
+            { name: 'Oidc__Microsoft__ClientId', value: microsoftClientId }
+          ])
+          volumeMounts: commonVolumeMounts
+        }
+      ]
+      scale: {
+        minReplicas: 0
+        maxReplicas: 5
+        rules: [
+          {
+            name: 'http-scale'
+            http: {
+              metadata: {
+                concurrentRequests: '20'
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+// ── Streaming ────────────────────────────────────────────────────────────────
+resource streamingApp 'Microsoft.App/containerApps@2024-03-01' = {
+  name: '${prefix}-streaming'
+  location: location
+  properties: {
+    environmentId: envId
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 8080
+        transport: 'http'
+        corsPolicy: {
+          allowedOrigins: ['*']
+          allowedHeaders: ['*']
+          allowedMethods: ['GET', 'HEAD', 'OPTIONS']
+        }
+      }
+      secrets: commonSecrets
+    }
+    template: {
+      volumes: commonVolumes
+      containers: [
+        {
+          name: 'streaming'
+          image: '${registry}/${ghcrOwner}/muxity-streaming:${imageTag}'
+          resources: {
+            cpu: json('0.25')
+            memory: '0.5Gi'
+          }
+          env: union(commonEnv, [
+            { name: 'Jwt__Key', secretRef: 'jwt-key' }
+            { name: 'Jwt__Issuer', value: jwtIssuer }
+            { name: 'Cdn__Provider', value: 'Passthrough' }
+          ])
+          volumeMounts: commonVolumeMounts
+        }
+      ]
+      scale: {
+        minReplicas: 0
+        maxReplicas: 10
+        rules: [
+          {
+            name: 'http-scale'
+            http: {
+              metadata: {
+                concurrentRequests: '50'
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+// ── Transcoder ───────────────────────────────────────────────────────────────
+resource transcoderApp 'Microsoft.App/containerApps@2024-03-01' = {
+  name: '${prefix}-transcoder'
+  location: location
+  properties: {
+    environmentId: envId
+    configuration: {
+      secrets: union(commonSecrets, [
+        { name: 'rabbitmq-connection', value: rabbitMqConnectionString }
+      ])
+    }
+    template: {
+      volumes: commonVolumes
+      containers: [
+        {
+          name: 'transcoder'
+          image: '${registry}/${ghcrOwner}/muxity-transcoder:${imageTag}'
+          resources: {
+            cpu: json('1.0')
+            memory: '2Gi'
+          }
+          env: union(commonEnv, [
+            { name: 'RabbitMq__ConnectionString', secretRef: 'rabbitmq-connection' }
+            { name: 'Transcoder__HardwareAccel', value: 'Software' }
+            { name: 'Transcoder__MaxParallelJobs', value: '1' }
+          ])
+          volumeMounts: commonVolumeMounts
+        }
+      ]
+      scale: {
+        minReplicas: 0
+        maxReplicas: 3
+        rules: [
+          {
+            name: 'rabbitmq-scale'
+            custom: {
+              type: 'rabbitmq'
+              metadata: {
+                queueName: 'transcode_jobs'
+                queueLength: '1'
+              }
+              auth: [
+                {
+                  secretRef: 'rabbitmq-connection'
+                  triggerParameter: 'host'
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+output apiHostname string = apiApp.properties.configuration.ingress.fqdn
+output streamingHostname string = streamingApp.properties.configuration.ingress.fqdn

--- a/infra/azure/modules/containerAppsEnv.bicep
+++ b/infra/azure/modules/containerAppsEnv.bicep
@@ -1,0 +1,60 @@
+@description('Azure region for all resources')
+param location string
+
+@description('Name prefix for resources')
+param prefix string
+
+@description('Azure Files storage account name')
+param storageAccountName string
+
+@description('Azure Files share name')
+param fileShareName string
+
+@description('Azure Files storage account key')
+@secure()
+param storageAccountKey string
+
+var envName = '${prefix}-env'
+var storageMountName = 'muxity-storage'
+
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: '${prefix}-logs'
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+  }
+}
+
+resource containerAppsEnv 'Microsoft.App/managedEnvironments@2024-03-01' = {
+  name: envName
+  location: location
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalytics.properties.customerId
+        sharedKey: logAnalytics.listKeys().primarySharedKey
+      }
+    }
+  }
+}
+
+resource envStorage 'Microsoft.App/managedEnvironments/storages@2024-03-01' = {
+  parent: containerAppsEnv
+  name: storageMountName
+  properties: {
+    azureFile: {
+      accountName: storageAccountName
+      accountKey: storageAccountKey
+      shareName: fileShareName
+      accessMode: 'ReadWrite'
+    }
+  }
+}
+
+output envId string = containerAppsEnv.id
+output envName string = containerAppsEnv.name
+output storageMountName string = storageMountName

--- a/infra/azure/modules/cosmos.bicep
+++ b/infra/azure/modules/cosmos.bicep
@@ -1,0 +1,51 @@
+@description('Azure region for all resources')
+param location string
+
+@description('Name prefix for resources')
+param prefix string
+
+var accountName = '${prefix}-cosmos'
+var databaseName = 'muxity'
+
+resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2024-02-15-preview' = {
+  name: accountName
+  location: location
+  kind: 'MongoDB'
+  properties: {
+    databaseAccountOfferType: 'Standard'
+    enableFreeTier: true
+    apiProperties: {
+      serverVersion: '7.0'
+    }
+    consistencyPolicy: {
+      defaultConsistencyLevel: 'Session'
+    }
+    locations: [
+      {
+        locationName: location
+        failoverPriority: 0
+        isZoneRedundant: false
+      }
+    ]
+    capabilities: [
+      { name: 'EnableMongo' }
+      { name: 'DisableRateLimitingResponses' }
+    ]
+  }
+}
+
+resource mongoDatabase 'Microsoft.DocumentDB/databaseAccounts/mongodbDatabases@2024-02-15-preview' = {
+  parent: cosmosAccount
+  name: databaseName
+  properties: {
+    resource: {
+      id: databaseName
+    }
+    options: {
+      throughput: 1000
+    }
+  }
+}
+
+output connectionString string = cosmosAccount.listConnectionStrings().connectionStrings[0].connectionString
+output databaseName string = databaseName

--- a/infra/azure/modules/staticWebApp.bicep
+++ b/infra/azure/modules/staticWebApp.bicep
@@ -1,0 +1,37 @@
+@description('Azure region for all resources')
+param location string
+
+@description('Name prefix for resources')
+param prefix string
+
+@description('GitHub repository URL (e.g. https://github.com/rfsprog/Muxity)')
+param repositoryUrl string
+
+@description('GitHub branch to deploy from')
+param branch string = 'main'
+
+@description('GitHub personal access token for Static Web Apps')
+@secure()
+param repositoryToken string
+
+resource staticWebApp 'Microsoft.Web/staticSites@2023-01-01' = {
+  name: '${prefix}-web'
+  location: location
+  sku: {
+    name: 'Free'
+    tier: 'Free'
+  }
+  properties: {
+    repositoryUrl: repositoryUrl
+    branch: branch
+    repositoryToken: repositoryToken
+    buildProperties: {
+      appLocation: 'src/Muxity.Web'
+      outputLocation: 'wwwroot'
+      appBuildCommand: 'dotnet publish -c Release -o published'
+    }
+  }
+}
+
+output defaultHostname string = staticWebApp.properties.defaultHostname
+output deploymentToken string = staticWebApp.listSecrets().properties.apiKey

--- a/infra/azure/modules/storage.bicep
+++ b/infra/azure/modules/storage.bicep
@@ -1,0 +1,40 @@
+@description('Azure region for all resources')
+param location string
+
+@description('Name prefix for resources')
+param prefix string
+
+var storageAccountName = '${replace(prefix, '-', '')}st'
+var fileShareName = 'muxity-data'
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: storageAccountName
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    minimumTlsVersion: 'TLS1_2'
+    supportsHttpsTrafficOnly: true
+    accessTier: 'Hot'
+  }
+}
+
+resource fileService 'Microsoft.Storage/storageAccounts/fileServices@2023-01-01' = {
+  parent: storageAccount
+  name: 'default'
+}
+
+resource fileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2023-01-01' = {
+  parent: fileService
+  name: fileShareName
+  properties: {
+    shareQuota: 100
+    enabledProtocols: 'SMB'
+  }
+}
+
+output storageAccountName string = storageAccount.name
+output fileShareName string = fileShareName
+output storageAccountKey string = storageAccount.listKeys().keys[0].value

--- a/infra/azure/parameters.json
+++ b/infra/azure/parameters.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "value": "eastus"
+    },
+    "prefix": {
+      "value": "muxity"
+    },
+    "repositoryUrl": {
+      "value": "https://github.com/rfsprog/Muxity"
+    },
+    "branch": {
+      "value": "main"
+    },
+    "repositoryToken": {
+      "reference": {
+        "keyVault": { "id": "" },
+        "secretName": "github-pat"
+      }
+    },
+    "rabbitMqConnectionString": {
+      "reference": {
+        "keyVault": { "id": "" },
+        "secretName": "rabbitmq-connection"
+      }
+    },
+    "jwtSigningKey": {
+      "reference": {
+        "keyVault": { "id": "" },
+        "secretName": "jwt-signing-key"
+      }
+    },
+    "googleClientId": {
+      "value": ""
+    },
+    "microsoftClientId": {
+      "value": ""
+    },
+    "imageTag": {
+      "value": "latest"
+    },
+    "ghcrOwner": {
+      "value": "rfsprog"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Deploys Muxity to Azure using Container Apps Consumption plan — scales to zero when idle, estimated **$0–5/month** for a sandbox/preview.

## Architecture

```
GitHub Actions
  ├── build-images → ghcr.io/rfsprog/muxity-{api,streaming,transcoder}:sha
  ├── deploy-infra → Bicep (Container Apps env, Cosmos DB, Storage, Static Web App)
  └── deploy-web   → Azure Static Web Apps (Blazor WASM, free tier)

Azure Resources
  ├── Container Apps Environment
  │   ├── muxity-api          (0–5 replicas, HTTP scaler)
  │   ├── muxity-streaming    (0–10 replicas, HTTP scaler)
  │   └── muxity-transcoder   (0–3 replicas, KEDA RabbitMQ scaler)
  ├── Azure Static Web App    (Blazor WASM — free tier)
  ├── Azure Cosmos DB         (MongoDB API 7.0 — free tier: 1000 RU/s, 25GB)
  ├── Azure Storage Account
  │   └── Azure Files share   (/data/storage mounted to all 3 container apps)
  └── Log Analytics workspace
```

## Files added

| File | Purpose |
|------|---------|
| `infra/azure/main.bicep` | Orchestrates all modules |
| `infra/azure/modules/storage.bicep` | Storage account + Azure Files share |
| `infra/azure/modules/cosmos.bicep` | Cosmos DB (MongoDB API, free tier) |
| `infra/azure/modules/containerAppsEnv.bicep` | Container Apps environment + Files mount |
| `infra/azure/modules/containerApps.bicep` | api, streaming, transcoder Container Apps |
| `infra/azure/modules/staticWebApp.bicep` | Free tier Static Web App |
| `infra/azure/parameters.json` | Parameter template |
| `infra/azure/deploy.sh` | One-shot provisioning script |
| `infra/azure/DEPLOY.md` | Setup guide with required secrets/variables |
| `.github/workflows/azure-deploy.yml` | CI/CD: build → push → deploy on every push to main |

## How to deploy

### First time
```bash
az login
bash infra/azure/deploy.sh
```

### After first deploy (GitHub Actions)
Add secrets to repo settings — see `infra/azure/DEPLOY.md` for the full list. Push to `main` triggers the workflow automatically.

Closes #9

https://claude.ai/code/session_012Dc8ReDLChwkiy1NjKv5dc